### PR TITLE
Duplicate get_dsinfo_xml subroutine

### DIFF
--- a/PhaidraAPI/Model/Search.pm
+++ b/PhaidraAPI/Model/Search.pm
@@ -834,29 +834,5 @@ sub _get_dsinfo_xml {
   }
 }
 
-sub _get_objectinfo_xml {
-
-  my ($self, $c, $pid, $cmodel) = @_;
-  
-  my %params;  
-  $params{DS} = "$pid+OCTETS+OCTETS.0";
-  $params{type} = $cmodel;
-  my $url = Mojo::URL->new;
-  $url->scheme('https');
-  $url->host($c->app->config->{phaidra}->{fedorabaseurl});
-  $url->path("dsinfo/dsinfo.cgi");
-  $url->query(\%params);
-
-  my $ua = Mojo::UserAgent->new;
-  my $tx = $ua->get($url);
-
-  if (my $reply = $tx->success) {
-  	return $reply->body;           
-  }else{
-    $c->app->log->error("Error getting filesize from dsinfo: ".$c->app->dumper($tx->error));
-  }
-}
-
-
 1;
 __END__


### PR DESCRIPTION
Subroutine _get_objectinfo_xml has the same code of _get_dsinfo_xml and it's not used anywhere.