### PR TITLE
datacite utf-8 encoding fix

### DIFF
--- a/PhaidraAPI/Controller/Datacite.pm
+++ b/PhaidraAPI/Controller/Datacite.pm
@@ -29,11 +29,6 @@ sub get {
     return;
   }
 
-  # when extracting metadata using Mojo::DOM we use ->content which returns UTF-8 encoded data
-  # since we're not going to save the data to fedora but render them, we need to decode them first before passing it to renderer because
-  # the renderer will UTF-8 encode the data again
-  $self->_decode_rec(undef, $res->{datacite}->{datacite_elements});
-
   if($format eq 'xml'){
     $self->render(text => $model->json_2_xml($self, $res->{datacite}->{datacite_elements}), format => 'xml');
     return;
@@ -48,39 +43,5 @@ sub get {
   );
 
 }
-
-sub _decode_rec(){
-
-  my $self = shift;
-  my $parent = shift;
-  my $children = shift;
-
-  foreach my $child (@{$children}){
-
-    my $children_size = defined($child->{children}) ? scalar (@{$child->{children}}) : 0;
-    my $attributes_size = defined($child->{attributes}) ? scalar (@{$child->{attributes}}) : 0;
-
-    if((!defined($child->{value}) || ($child->{value} eq '')) && $children_size == 0 && $attributes_size == 0){
-      next;
-    }
-
-    if (defined($child->{attributes}) && (scalar @{$child->{attributes}} > 0)){
-      my @attrs;
-      foreach my $a (@{$child->{attributes}}){
-        if(defined($a->{value}) && $a->{value} ne ''){
-          $a->{value} = b($a->{value})->decode('UTF-8');
-        }
-      }
-    }
-
-    if($children_size > 0){
-      $self->_decode_rec($child, $child->{children});
-    }else{
-      $child->{value} = b($child->{value})->decode('UTF-8');
-    }
-
-  }
-}
-
 
 1;

--- a/PhaidraAPI/Model/Datacite.pm
+++ b/PhaidraAPI/Model/Datacite.pm
@@ -67,7 +67,7 @@ sub get {
     if($r1->{status} ne 200){
       return $r1;
     }
-
+    $r1->{MODS} = b($r1->{MODS})->decode('UTF-8');
     my $datacite = $self->map_mods_2_datacite($c, $pid, $cmodel, $r1->{MODS});
 
     $res->{datacite} = $datacite;
@@ -79,7 +79,7 @@ sub get {
     if($r1->{status} ne 200){
       return $r1;
     }
-
+    $r1->{UWMETADATA} = b($r1->{UWMETADATA})->decode('UTF-8');
     my $datacite = $self->map_uwmetadata_2_datacite($c, $pid, $cmodel, $r1->{UWMETADATA});
 
     $res->{datacite} = $datacite;


### PR DESCRIPTION
Model/Object->get_datastream subroutine doesn't return UTF-8 decoded datastream, so we need to decode it in Model/Datacite->get. Calling Controller/Datacite->_decoded_rec isn't needed anymore.