### PR TITLE
FileHandle shouldn't be needed anymore

### DIFF
--- a/phaidra-api.cgi
+++ b/phaidra-api.cgi
@@ -2,7 +2,6 @@
 
 use strict;
 use warnings;
-use FileHandle; # temporary fix for https://groups.google.com/d/topic/mojolicious/y9J88fboW50/discussion
 use lib('/usr/local/phaidra/phaidra-api');
 
 # Start command line interface for application


### PR DESCRIPTION
When using 7.x or later versions of Mojolicious.