### PR TITLE
UTF-8 chars in code

### DIFF
--- a/PhaidraAPI/Model/Uwmetadata.pm
+++ b/PhaidraAPI/Model/Uwmetadata.pm
@@ -3,6 +3,7 @@ package PhaidraAPI::Model::Uwmetadata;
 use strict;
 use warnings;
 use v5.10;
+use utf8;
 use base qw/Mojo::Base/;
 use Storable qw(dclone);
 use POSIX qw/strftime/;


### PR DESCRIPTION
`use utf8` is needed for `{ en => 'Yes', de => 'Ja', it => 'Sì' }`